### PR TITLE
Store commenter's email in Datastore alongside comment text.

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -1,0 +1,27 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.data;
+
+/** User comment and the email address the comment was written by. */
+public class Comment {
+
+  private final String text;
+  private final String email;
+
+  public Comment(String email, String text) {
+    this.email = email;
+    this.text = text;
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -31,6 +31,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.sps.data.Comment;
 
 /** Servlet that returns some example content. */
 @WebServlet("/data")
@@ -53,16 +54,13 @@ public class DataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(maxComments);
 
-    ArrayList<HashMap> comments = new ArrayList<>();
+    ArrayList<Comment> comments = new ArrayList<>();
     
     for (Entity entity : results.asIterable(fetchOptions)) {
-      HashMap<String, String> comment = new HashMap<String, String>();
+      String email = (String) entity.getProperty("email");
+      String text = (String) entity.getProperty("text");
       
-      String userEmail = (String) entity.getProperty("email");
-      String commentText = (String) entity.getProperty("text");
-      
-      comment.put("email", userEmail);
-      comment.put("text", commentText);
+      Comment comment = new Comment(email, text);
 
       comments.add(comment);
     }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -53,6 +53,7 @@ function addRandomFact() {
  */
 function getComments() {
   const commentLimit = 15;
+
   let maxComments;
   try {
     maxComments = document.getElementById('max-comments').value;
@@ -78,7 +79,7 @@ function getComments() {
     for (message of messages) {
       const commentContainer = document.createElement('div');
       commentContainer.className += 'comment-container';
-      commentContainer.innerText = message;
+      commentContainer.innerText = message.email + ': ' + message.text;
 
       document.getElementById('message-container')
           .appendChild(commentContainer);


### PR DESCRIPTION
This commit changes the original structure of the comments JSON so the comments don't display onto the page (yet). Currently the email address of the commenter and their comment text is stored in Datastore and JSON is printed to /data so it can be fetched. 