### PR TITLE
Add input for commenter's name and displays it with comment.

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -17,12 +17,12 @@ package com.google.sps.data;
 /** User comment and the email address the comment was written by. */
 public class Comment {
 
+  private final String nickname;
   private final String text;
-  private final String email;
   private final Double score;
 
-  public Comment(String email, String text, Double score) {
-    this.email = email;
+  public Comment(String nickname, String text, Double score) {
+    this.nickname = nickname;
     this.text = text;
     this.score = score;
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -84,7 +84,7 @@ public class DataServlet extends HttpServlet {
       long timestamp = System.currentTimeMillis();
       String email = userService.getCurrentUser().getEmail();
       String nickname = request.getParameter("nickname-input");
-      float score = 0.2f;//calculateSentimentScore(commentText);
+      float score = calculateSentimentScore(commentText);
       
       Entity commentEntity = new Entity("Comment");
       commentEntity.setProperty("text", commentText);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -59,11 +59,11 @@ public class DataServlet extends HttpServlet {
     ArrayList<Comment> comments = new ArrayList<>();
     
     for (Entity entity : results.asIterable(fetchOptions)) {
-      String email = (String) entity.getProperty("email");
+      String nickname = (String) entity.getProperty("nickname");
       String text = (String) entity.getProperty("text");
       Double score = (double) entity.getProperty("score");
 
-      comments.add(new Comment(email, text, score));
+      comments.add(new Comment(nickname, text, score));
     }
 
     // Convert comments ArrayList to JSON String using GSON library. 
@@ -83,12 +83,14 @@ public class DataServlet extends HttpServlet {
       String commentText = request.getParameter("comment-input");
       long timestamp = System.currentTimeMillis();
       String email = userService.getCurrentUser().getEmail();
-      float score = calculateSentimentScore(commentText);
+      String nickname = request.getParameter("nickname-input");
+      float score = 0.2f;//calculateSentimentScore(commentText);
       
       Entity commentEntity = new Entity("Comment");
       commentEntity.setProperty("text", commentText);
       commentEntity.setProperty("timestamp", timestamp);
       commentEntity.setProperty("email", email);
+      commentEntity.setProperty("nickname", nickname);
       commentEntity.setProperty("score", score);
 
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -78,7 +78,7 @@ function getComments() {
 
     for (message of messages) {
       const commentContainer =
-          createCommentContainer(message.email, message.text, message.score);
+          createCommentContainer(message.nickname, message.text, message.score);
 
       document.getElementById('message-container')
           .appendChild(commentContainer);
@@ -147,7 +147,7 @@ function createLoginPromptElement(isLoggedIn, url) {
 
 /**
  * Creates and returns a form element for users to submit comments.
- * @return {!HTMLFormElement} Form element with a text field and submit button
+ * @return {!HTMLFormElement} Form element with text fields and submit button.
  */
 function createCommentFormElement() {
   const form = document.createElement('form');
@@ -155,15 +155,35 @@ function createCommentFormElement() {
   form.setAttribute('method', 'POST');
   form.setAttribute('id', 'input-form');
 
-  const textField = document.createElement('input');
-  textField.setAttribute('type', 'text');
-  textField.setAttribute('name', 'comment-input');
-  textField.setAttribute('placeholder', 'Write your comment here!');
+  const nameLabel = document.createElement('label');
+  nameLabel.setAttribute('for', 'nickname-input');
+  nameLabel.appendChild(document.createTextNode('Name*'))
+
+  const nameField = document.createElement('input');
+  nameField.required = true;
+  nameField.setAttribute('type', 'text');
+  nameField.setAttribute('name', 'nickname-input');
+  nameField.setAttribute('id', 'nickname-input');
+  nameField.setAttribute('placeholder', 'Enter a display name.');
+
+  const commentLabel = document.createElement('label');
+  commentLabel.setAttribute('for', 'comment-input');
+  commentLabel.appendChild(document.createTextNode('Comment*'))
+
+  const commentField = document.createElement('input');
+  commentField.required = true;
+  commentField.setAttribute('type', 'text');
+  commentField.setAttribute('name', 'comment-input');
+  commentField.setAttribute('id', 'comment-input');
+  commentField.setAttribute('placeholder', 'Write your comment here!');
 
   const submitButton = document.createElement('input');
   submitButton.setAttribute('type', 'submit');
 
-  form.appendChild(textField);
+  form.appendChild(nameLabel);
+  form.appendChild(nameField);
+  form.appendChild(commentLabel);
+  form.appendChild(commentField);
   form.appendChild(submitButton);
 
   return form;
@@ -171,19 +191,19 @@ function createCommentFormElement() {
 
 /**
  * Creates and returns a div element for a single comment.
- * @param {string} email A string of the commenter's email address. 
+ * @param {string} name A string of the commenter's display name.
  * @param {string} text A string of comment input. 
  * @param {double} score A double of the comment's sentiment score. 
  * @return {!HTMLDivElement} Div element that displays comment data. 
  */
-function createCommentContainer(email, text, score) {
+function createCommentContainer(name, text, score) {
   // Create div that contains a comment's information.
   const commentContainer = document.createElement('div');
   commentContainer.className += 'comment-container';
 
-  // Paragraph element that displays user email and comment.
+  // Paragraph element that displays user's name and comment.
   const commentPara = document.createElement('p');
-  commentPara.innerText = email + ': ' + text;
+  commentPara.innerText = name + ': ' + text;
   commentContainer.appendChild(commentPara);
 
   // Paragraph element that displays sentiment score. 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -94,6 +94,12 @@ a:hover, a:active {
   margin-top: 20px;
 }
 
+#comment-form form {
+  display: grid;
+  grid-template-columns: 80px 300px;
+  grid-gap: 10px;
+}
+
 .comment-container {
   margin: 15px 0px 15px 0px;
   padding-left: 15px;


### PR DESCRIPTION
Instead of displaying commenter emails, display an inputted username instead. Now emails are only stored in Datastore, and not stored in the JSON object that's fetched from /data. Names are required to be input to submit a comment. 