### PR TITLE
Add scheduling functionality for optional attendees.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -74,13 +74,11 @@ public final class FindMeetingQuery {
       for (TimeRange optionalTime : optionalTimes) {
         if (mandatoryTime.contains(optionalTime)) {
           times.add(optionalTime);
-        }
-        else if (optionalTime.contains(mandatoryTime)) {
+        } else if (optionalTime.contains(mandatoryTime)) {
           times.add(mandatoryTime);
-        }
-        else if (mandatoryTime.overlaps(optionalTime)) {
-          int start = mandatoryTime.start() > optionalTime.start() ? mandatoryTime.start() : optionalTime.start();
-          int end = mandatoryTime.end() < optionalTime.end() ? mandatoryTime.end() : optionalTime.end();
+        } else if (mandatoryTime.overlaps(optionalTime)) {
+          int start = Math.max(mandatoryTime.start(), optionalTime.start());
+          int end = Math.min(mandatoryTime.end(), optionalTime.end());
 
           TimeRange time = TimeRange.fromStartEnd(start, end, false);
           if (time.duration() >= request.getDuration()) {

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -416,5 +416,35 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void overlappingMandatoryAndOptionalTimes() {
+    // The available times for mandatory and optional attendees overlap. Only the overlapping time
+    // should be returned.
+    //
+    // Event   : |---A---|     |---A---|
+    // Optional: |----B----|     |--B--|
+    // Day     : |---------------------|
+    // Options :           |---|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 4", TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, false),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM,
+        DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
 }
 


### PR DESCRIPTION
```query()``` now finds available times for both mandatory attendee events and optional attendee events and then finds common times that allow for both groups to meet. If there are no mandatory attendees, then only optional attendee schedules are considered. If there are no times for both mandatory and optional people to meet, then only mandatory attendee schedules are considered. 

Also added a test, ```overlappingMandatoryAndOptionalTimes()```, to check if the correct time range is returned when the available time that mandatory people and optional people can meet are overlapping. Only the overlapping time should be returned. 